### PR TITLE
useContext

### DIFF
--- a/11_hooks_p1/src/030_useContext/start/Example.jsx
+++ b/11_hooks_p1/src/030_useContext/start/Example.jsx
@@ -1,8 +1,11 @@
+import { useContext } from "react";
 import Child from "./components/Child";
+import { createContext } from "react";
+
+export const MyContext = createContext("hello");
 
 const Example = () => {
-  const value = 'hello'
-  return <Child value={value}/>;
+  return <Child />;
 };
 
 export default Example;

--- a/11_hooks_p1/src/030_useContext/start/components/Child.jsx
+++ b/11_hooks_p1/src/030_useContext/start/components/Child.jsx
@@ -1,9 +1,9 @@
 import GrandChild from "./GrandChild";
 
-const Child = ({ value }) => (
+const Child = () => (
   <div style={{ border: "1px solid black", padding: 10 }}>
     <h3>子コンポーネント</h3>
-    <GrandChild value={value} />
+    <GrandChild />
   </div>
 );
 

--- a/11_hooks_p1/src/030_useContext/start/components/GrandChild.jsx
+++ b/11_hooks_p1/src/030_useContext/start/components/GrandChild.jsx
@@ -1,9 +1,13 @@
-const GrandChild = ({ value }) => {
+import { useContext } from "react";
+import { MyContext } from "../Example";
+
+const GrandChild = () => {
+  const value = useContext(MyContext);
   return (
-      <div style={{ border: "1px solid black" }}>
-        <h3>孫コンポーネント</h3>
-        {value}
-      </div>
+    <div style={{ border: "1px solid black" }}>
+      <h3>孫コンポーネント</h3>
+      {value}
+    </div>
   );
 };
 export default GrandChild;

--- a/11_hooks_p1/src/040_useContext_with_state/start/Example.jsx
+++ b/11_hooks_p1/src/040_useContext_with_state/start/Example.jsx
@@ -1,14 +1,16 @@
-import { createContext } from "react";
+import { createContext, useState } from "react";
 import Child from "./components/Child";
 import OtherChild from "./components/OtherChild";
-export const MyContext = createContext("hello");
+export const MyContext = createContext();
 
 const Example = () => {
+  const [value, setValue] = useState(0);
+
   return (
-    <>
+    <MyContext.Provider value={[value, setValue]}>
       <Child />
       <OtherChild />
-    </>
+    </MyContext.Provider>
   );
 };
 

--- a/11_hooks_p1/src/040_useContext_with_state/start/components/GrandChild.jsx
+++ b/11_hooks_p1/src/040_useContext_with_state/start/components/GrandChild.jsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import { MyContext } from "../Example";
 const GrandChild = () => {
-  const value = useContext(MyContext);
+  const [value] = useContext(MyContext);
   return (
     <div style={{ border: "1px solid black" }}>
       <h3>孫コンポーネント</h3>

--- a/11_hooks_p1/src/040_useContext_with_state/start/components/OtherChild.jsx
+++ b/11_hooks_p1/src/040_useContext_with_state/start/components/OtherChild.jsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useContext } from "react";
+import { MyContext } from "../Example";
 
 const OtherChild = () => {
-  const [ value, setValue ] = useState(0);
-
+  const [, setValue] = useContext(MyContext);
   const clickHandler = (e) => {
     setValue((prev) => prev + 1);
   };
@@ -11,7 +11,6 @@ const OtherChild = () => {
     <div>
       <h3>他の子コンポーネント</h3>
       <button onClick={clickHandler}>+</button>
-      <h3>{value}</h3>
     </div>
   );
 };

--- a/11_hooks_p1/src/050_context_file/start/Example.jsx
+++ b/11_hooks_p1/src/050_context_file/start/Example.jsx
@@ -1,22 +1,16 @@
-import { useState } from "react";
 import "./Example.css";
+import Header from "./components/Header";
+import Main from "./components/Main";
+import Footer from "./components/Footer";
+import { ThemeProvider } from "./context/themeContext";
 
 const Example = () => {
-  const [theme, setTheme] = useState('light')
-  
-  const changeTheme = (e) => setTheme(e.target.value)
-  
-  const THEMES = ['light', 'dark', 'red'];
-
   return (
-    <>
-      <header className={`content-${theme}`}>
-        
-      </header>
-      <main className={`content-${theme}`}>
-        <h1>テーマの切り替え</h1>
-      </main>
-    </>
+    <ThemeProvider>
+      <Header />
+      <Main />
+      <Footer />
+    </ThemeProvider>
   );
 };
 

--- a/11_hooks_p1/src/050_context_file/start/components/Footer.jsx
+++ b/11_hooks_p1/src/050_context_file/start/components/Footer.jsx
@@ -1,0 +1,14 @@
+import { useUpdateTheme } from "../context/themeContext";
+
+const Footer = () => {
+  const setTheme = useUpdateTheme();
+
+  console.log("フッター");
+  return (
+    <footer>
+      <div>フッター</div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/11_hooks_p1/src/050_context_file/start/components/Header.jsx
+++ b/11_hooks_p1/src/050_context_file/start/components/Header.jsx
@@ -1,5 +1,30 @@
+import { useTheme, useUpdateTheme } from "../context/themeContext";
+
 const Header = () => {
-  
+  const THEMES = ["light", "dark", "red"];
+
+  const theme = useTheme();
+  const setTheme = useUpdateTheme();
+
+  const changeTheme = (e) => setTheme(e.target.value);
+
+  return (
+    <header className={`content-${theme}`}>
+      {THEMES.map((_theme) => {
+        return (
+          <label key={_theme}>
+            <input
+              type="radio"
+              value={_theme}
+              checked={theme === _theme}
+              onChange={changeTheme}
+            />
+            {_theme}
+          </label>
+        );
+      })}
+    </header>
+  );
 };
 
 export default Header;

--- a/11_hooks_p1/src/050_context_file/start/components/Main.jsx
+++ b/11_hooks_p1/src/050_context_file/start/components/Main.jsx
@@ -1,5 +1,13 @@
+import { useTheme } from "../context/themeContext";
+
 const Main = () => {
-  
+  const theme = useTheme();
+
+  return (
+    <main className={`content-${theme}`}>
+      <h1>テーマの切り替え</h1>
+    </main>
+  );
 };
 
 export default Main;

--- a/11_hooks_p1/src/050_context_file/start/context/ThemeContext.jsx
+++ b/11_hooks_p1/src/050_context_file/start/context/ThemeContext.jsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, useState } from "react";
+
+export const ThemeContext = createContext();
+export const ThemeUpdateContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState("light");
+
+  return (
+    <ThemeContext.Provider value={theme}>
+      <ThemeUpdateContext.Provider value={setTheme}>
+        {children}
+      </ThemeUpdateContext.Provider>
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);
+export const useUpdateTheme = () => useContext(ThemeUpdateContext);


### PR DESCRIPTION
概要
- useContextを使うことでpropsのバケツリレーを防げる
- 一般的にはロケール、タイムゾーン、テーマなどアプリ全体で利用する値の管理に使う
- contextを管理するファイルを作成することで、読みやすいコードとなる
- createContextで作成したコンテキストをuseContextで読み込み
- Providerに渡したvalueがpropsの代わりとなる